### PR TITLE
feat: Add new sample for opaque type in Index.scala

### DIFF
--- a/examples/client/src/main/scala/Index.scala
+++ b/examples/client/src/main/scala/Index.scala
@@ -24,6 +24,7 @@ object App extends App {
 
   private val demos = Seq(
     samples.simple,
+    samples.opaque,
     samples.either,
     samples.validation,
     samples.enums,

--- a/examples/client/src/main/scala/samples/OpaqueType.scala
+++ b/examples/client/src/main/scala/samples/OpaqueType.scala
@@ -1,0 +1,36 @@
+package samples
+
+import com.raquo.laminar.api.L.*
+import dev.cheleb.scalamigen.*
+
+val opaque = {
+
+  case class Person(
+      name: String,
+      password: Password
+  )
+
+  val simpleVar = Var(Person("Vlad", Password("123456")))
+  Sample(
+    "Opaque Type",
+    simpleVar.asForm,
+    div(
+      child <-- simpleVar.signal.map { item =>
+        div(
+          s"$item"
+        )
+      }
+    ),
+    """
+    |case class Person(
+    |                name: String,
+    |                weight: Int,
+    |                hairsCount: BigInt :| GreaterEqual[100000],
+    |                kind: Boolean = true)
+    |
+    |val simpleVar = Var(Person("Vlad", 66, BigInt(100000).refineUnsafe))
+    |
+    |simpleVar.asForm
+    """.stripMargin
+  )
+}


### PR DESCRIPTION
Add a new sample for opaque type in the Index.scala file. This sample demonstrates the usage of an opaque type in a case class called Person, which includes a name and a password. The sample also includes a simpleVar variable that holds an instance of Person and renders it in the UI.