### PR TITLE
chore(deps): update vite to version 5.4.11 in package.json and package-lock.json

### DIFF
--- a/examples/client/package-lock.json
+++ b/examples/client/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@scala-js/vite-plugin-scalajs": "^1.0.0",
-        "vite": "^5.4.10"
+        "vite": "^5.4.11"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -917,9 +917,9 @@
       "peer": true
     },
     "node_modules/vite": {
-      "version": "5.4.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
-      "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/client/package.json
+++ b/examples/client/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@scala-js/vite-plugin-scalajs": "^1.0.0",
-    "vite": "^5.4.10"
+    "vite": "^5.4.11"
   }
 }

--- a/modules/core/src/main/scala/dev/cheleb/scalamigen/Defaultable.scala
+++ b/modules/core/src/main/scala/dev/cheleb/scalamigen/Defaultable.scala
@@ -26,9 +26,23 @@ trait Defaultable[A] {
 
 object Defaultable {
 
+  given Defaultable[Boolean] with
+    def default = false
+
   /** Default value for Int is 0.
     */
   given Defaultable[Int] with
+    def default = 0
+
+  given Defaultable[Double] with
+    def default = 0
+
+  given Defaultable[Float] with
+    def default = 0
+
+  given Defaultable[BigDecimal] with
+    def default = 0
+  given Defaultable[BigInt] with
     def default = 0
 
   /** Default value for String is "".


### PR DESCRIPTION
feat: add default instances for Boolean, Double, Float, BigDecimal, and BigInt in Defaultable trait