### PR TITLE
feat(forms): add sample 'conditional'

### DIFF
--- a/examples/client/src/main/scala/Index.scala
+++ b/examples/client/src/main/scala/Index.scala
@@ -27,6 +27,7 @@ object App extends App {
     samples.opaque,
     samples.either,
     samples.validation,
+    samples.conditional,
     samples.enums,
     samples.sealedClasses,
     samples.person,

--- a/examples/client/src/main/scala/samples/Conditional.scala
+++ b/examples/client/src/main/scala/samples/Conditional.scala
@@ -1,0 +1,110 @@
+package samples
+
+import dev.cheleb.scalamigen.*
+import com.raquo.laminar.api.L.*
+
+case class Person(
+    firstname: String, 
+    lastname: String, 
+    age: Int, 
+    extra_str: Option[ExtraString],
+    extra_int: Option[ExtraInt]
+  )
+
+object Person:
+    val empty = Person("John", "Doe", 16, None, None)
+
+@Panel("Conditional", false)
+case class ConditionalSample(
+    person: Person,
+)
+
+given ConditionalFor[ConditionalSample, ExtraString] with
+  def check = _.person.age >= 18
+
+given ConditionalFor[ConditionalSample, ExtraInt] with
+  def check = _.person.age >= 18
+
+given Defaultable[Person] with
+    def default = Person.empty
+
+val conditionalVar = Var(ConditionalSample(Person.empty))
+
+given formExtraString: Form[Option[ExtraString]] = 
+    Form.conditionalOn[ConditionalSample, ExtraString](conditionalVar)
+
+given formExtraInt: Form[Option[ExtraInt]] = 
+    Form.conditionalOn[ConditionalSample, ExtraInt](conditionalVar)
+
+val conditional = {
+  
+  Sample(
+    "Conditional",
+    conditionalVar.asForm,
+    div(child <-- conditionalVar.signal.map { item =>
+      div(
+        s"$item"
+      )
+    }),
+    """|opaque type ExtraString = String
+       |object ExtraString:
+       |    def apply(s: String): ExtraString = s
+       |    // given Form[ExtraString] = stringForm(identity)
+       |    given Form[ExtraString] = stringFormWithValidation(using 
+       |        new Validator[ExtraString] {
+       |            override def validate(str: String): Either[String, ExtraString] = 
+       |                str.matches("^[a-fA-F0-9]+$") match
+       |                    case true => Right(str)
+       |                    case false => Left("expected hexadecimal string (just for demo)")
+       |        }
+       |    )
+       |    given Defaultable[ExtraString] with
+       |        def default: ExtraString = ""
+       |
+       |opaque type ExtraInt = Int
+       |object ExtraInt:
+       |    def apply(i: Int): ExtraInt = i
+       |    given Form[ExtraInt] = numericForm(_.toIntOption, 0)
+       |    given Defaultable[ExtraInt] with
+       |        def default: ExtraInt = 0
+       |
+       |// In another file
+       |
+       |case class Person(
+       |    firstname: String, 
+       |    lastname: String, 
+       |    age: Int, 
+       |    extra_str: Option[ExtraString],
+       |    extra_int: Option[ExtraInt]
+       |  )
+       |
+       |object Person:
+       |    val empty = Person("John", "Doe", 16, None, None)
+       |
+       |@Panel("Conditional", false)
+       |case class ConditionalSample(
+       |    person: Person,
+       |)
+       |
+       |given ConditionalFor[ConditionalSample, ExtraString] with
+       |  def check = _.person.age >= 18
+       |
+       |given ConditionalFor[ConditionalSample, ExtraInt] with
+       |  def check = _.person.age >= 18
+       |
+       |given Defaultable[Person] with
+       |    def default = Person.empty
+       |
+       |val conditionalVar = Var(ConditionalSample(Person.empty))
+       |
+       |given formExtraString: Form[Option[ExtraString]] = 
+       |    Form.conditionalOn[ConditionalSample, ExtraString](conditionalVar)
+       |
+       |given formExtraInt: Form[Option[ExtraInt]] = 
+       |    Form.conditionalOn[ConditionalSample, ExtraInt](conditionalVar)
+       |
+       |conditionalVar.asForm
+       |""".stripMargin
+  )
+
+}

--- a/examples/client/src/main/scala/samples/package.scala
+++ b/examples/client/src/main/scala/samples/package.scala
@@ -13,4 +13,27 @@ object Password:
   def apply(password: String): Password = password
   given Form[Password] = secretForm(apply)
 
+opaque type ExtraString = String
+object ExtraString:
+    def apply(s: String): ExtraString = s
+    // given Form[ExtraString] = stringForm(identity)
+    given Form[ExtraString] = stringFormWithValidation(using 
+        new Validator[ExtraString] {
+            override def validate(str: String): Either[String, ExtraString] = 
+                str.matches("^[a-fA-F0-9]+$") match
+                    case true => Right(str)
+                    case false => Left("expected hexadecimal string (just for demo)")
+        }
+    )
+    given Defaultable[ExtraString] with
+        def default: ExtraString = ""
+
+
+opaque type ExtraInt = Int
+object ExtraInt:
+    def apply(i: Int): ExtraInt = i
+    given Form[ExtraInt] = numericForm(_.toIntOption, 0)
+    given Defaultable[ExtraInt] with
+        def default: ExtraInt = 0
+
 given WidgetFactory = if true then UI5WidgetFactory else LaminarWidgetFactory

--- a/modules/core/src/main/scala/dev/cheleb/scalamigen/ConditionalFor.scala
+++ b/modules/core/src/main/scala/dev/cheleb/scalamigen/ConditionalFor.scala
@@ -1,0 +1,4 @@
+package dev.cheleb.scalamigen
+
+trait ConditionalFor[C, A]:
+    def check: C => Boolean


### PR DESCRIPTION
What do you think of adding this feature : conditionally showing a field (label and value) depending on the value of a variable.

I made an example that show 2 extra fields of type 'String' and 'Int' if the age of the person is older than 18.

See 'Conditional' tab in the examples / samples