### PR TITLE
feat(adhoc): allow to set FieldName and PanelConfig without annotations

### DIFF
--- a/examples/client/src/main/scala/Index.scala
+++ b/examples/client/src/main/scala/Index.scala
@@ -32,7 +32,8 @@ object App extends App {
     samples.sealedClasses,
     samples.person,
     samples.list,
-    samples.tree
+    samples.tree,
+    samples.adhoc
   )
 
   val myApp =

--- a/examples/client/src/main/scala/samples/AdHoc.scala
+++ b/examples/client/src/main/scala/samples/AdHoc.scala
@@ -1,0 +1,82 @@
+package samples
+
+import com.raquo.laminar.api.L.*
+import dev.cheleb.scalamigen.*
+import io.github.iltotore.iron.constraint.all.*
+
+val adhoc = {
+
+  // outside your scope / in another library
+  // => meaning '@FieldName' or '@NoPanel' annotations are not possible
+  case class Cat(
+      name: String,
+      kind: Boolean = true,
+      color: Color,
+  )
+
+  enum Color(val code: String):
+    case Black extends Color("000")
+    case White extends Color("FFF")
+    case Isabelle extends Color("???")
+
+  // your library
+  case class Basket(color: Color, cat: Cat)
+  
+  given colorForm: Form[Color] =
+    selectForm(Color.values, labelMapper = c => s"$c ${c.code}")
+      .withFieldName("Select color")
+
+  given Form[Cat] = 
+    Form.autoDerived[Cat]
+        .withFieldName("Your cat")
+        .withPanelConfig(label = Some("What kind of cat ?"), asTable = true)
+
+  val enumVar = Var(
+    Basket(
+      Color.Black,
+      Cat(
+        "Scala",
+        true,
+        Color.White,
+      )
+    )
+  )
+
+  Sample(
+    "Ad-Hoc",
+    enumVar.asForm(enumVar.errorBus),
+    div(
+      child <-- enumVar.signal.map { item =>
+        div(
+          s"$item"
+        )
+      }
+    ),
+    """|
+       |// outside your scope / in another library
+       |// => meaning '@FieldName' or '@NoPanel' annotations are not possible
+       |case class Cat(
+       |    name: String,
+       |    kind: Boolean = true,
+       |    color: Color,
+       |)
+       |
+       |enum Color(val code: String):
+       |  case Black extends Color("000")
+       |  case White extends Color("FFF")
+       |  case Isabelle extends Color("???")
+       |
+       |// your library
+       |case class Basket(color: Color, cat: Cat)
+       |
+       |given colorForm: Form[Color] =
+       |  selectForm(Color.values, labelMapper = c => s"$c ${c.code}")
+       |    .withFieldName("Select color")
+       |
+       |given Form[Cat] = 
+       |  Form.autoDerived[Cat]
+       |      .withFieldName("Your cat")
+       |      .withPanelConfig(label = Some("What kind of cat ?"), asTable = true)
+       |""".stripMargin
+  )
+}


### PR DESCRIPTION
Sometimes we don't have access to the underlying case class so we can not add '@FieldName', '@Panel' or '@NoPanel' annotations.

This is a proposal to update the autoDerivated 'Form' instance so we can customize this behaviour.

See new "Ad-Hoc" sample.

Also, it allows to have custom field name depending on other data (e.g.: internationalization)