### PR TITLE
chore(build): use scala 3 lts version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.bsp/
 node_modules/
 dist/
 *.bak

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.nio.charset.StandardCharsets
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-val scala3 = "3.6.3"
+val scala3 = "3.3.5"
 
 val tapirVersion = "1.11.14"
 


### PR DESCRIPTION
The current latest version is using the latest Scala 3.6 compiler, which means other projects based on Scala 3 that are not on that version cannot use it because of dependency conflicts:

```
[error] java.io.IOException: TASTy file scala/Tuple$package.tasty could not be read, failing with:
[error]   Forward incompatible TASTy file has version 28.6, produced by Scala 3.6.3-bin-nonbootstrapped,
[error]   expected stable TASTy from 28.0 to 28.5.
[error]   To read this TASTy file, use a newer version of this tool compatible with TASTy 28.6.
[error]   Please refer to the documentation for information on TASTy versioning:
[error]   https://docs.scala-lang.org/scala3/reference/language-versions/binary-compatibility.html
```

I'm not sure there is anything here that requires the newer Scala compilers and cannot be on LTS. 

However, the build does fail, one of the examples has this issue: https://github.com/scala/scala3/issues/20741 so perhaps that's the reason it's like that. Happy to find a workaround to make this LTS scala build happen though.
